### PR TITLE
Fix bug in angle_to_sexigesimal - angles seem to be doubled

### DIFF
--- a/participants/scipy_003/pr_tutorial/buggy_function.py
+++ b/participants/scipy_003/pr_tutorial/buggy_function.py
@@ -20,7 +20,7 @@ def angle_to_sexigesimal(angle_in_degrees, decimals=3):
     if math.floor(decimals) != decimals:
         raise OSError('decimals should be an integer!')
 
-    hours_num = angle_in_degrees*24/180
+    hours_num = angle_in_degrees*24/360
     hours = math.floor(hours_num)
 
     min_num = (hours_num - hours)*60

--- a/participants/scipy_003/pr_tutorial/tests/test_buggy_function.py
+++ b/participants/scipy_003/pr_tutorial/tests/test_buggy_function.py
@@ -1,0 +1,4 @@
+from pr_tutorial.buggy_function import angle_to_sexigesimal
+
+def test_angle_to_sexigesimal():
+    assert angle_to_sexigesimal(360) == "24:0:0.000"


### PR DESCRIPTION
I believe i found a bug in the `angle_to_sexigesimal` function in the `buggy_function` module. The angles seem to come out doubled. For 360 degrees i would expect 24 hours, but the function currently gives 48 hours. I added a test for this case and fixed the function by dividing by 360 degrees instead of 180.