### PR TITLE
MAINT: changing event name description in setup

### DIFF
--- a/participants/scipy_050/setup.py
+++ b/participants/scipy_050/setup.py
@@ -1,5 +1,5 @@
 from setuptools import setup
 
-setup(name="AHW PR tutorial",
+setup(name="Scipy2025 PR tutorial",
       version="0.1",
       packages=["pr_tutorial", ])


### PR DESCRIPTION
A fix that should have happened before the BoF